### PR TITLE
[perl #120832] match -links checks against find(1) not expect

### DIFF
--- a/t/find2perl.t
+++ b/t/find2perl.t
@@ -141,7 +141,6 @@ my @testcases =
         },
         {
             args => [ "-links", "2" ],
-            expect => [ "abc", "link", "somedir" ],
         },
         {
             name => "[perl #113054] mapping of ?",


### PR DESCRIPTION
Some filesystems only simulate . and .. so an empty directory doesn't
have a link count of 2.
